### PR TITLE
Add support for receiving fields with - in their keys.

### DIFF
--- a/src/main/java/org/phlo/AirReceiver/RaopAudioHandler.java
+++ b/src/main/java/org/phlo/AirReceiver/RaopAudioHandler.java
@@ -298,7 +298,7 @@ public class RaopAudioHandler extends SimpleChannelUpstreamHandler {
 	 * <li> {@code <attribute>=aesiv} 
 	 * </ul>
 	 */
-	private static Pattern s_pattern_sdp_a = Pattern.compile("^([a-z]+):(.*)$");
+	private static Pattern s_pattern_sdp_a = Pattern.compile("^([a-z\\-]+):(.*)$");
 	
 	/**
 	 * SDP {@code a} attribute {@code rtpmap}. Format is


### PR DESCRIPTION
iPhone 4 (iOS 6) sends the following fields which doesn't match the validation
pattern, support for - in the field name fixes this.
min-latency:11025
max-latency:88200
